### PR TITLE
Use send for #define_method

### DIFF
--- a/lib/app_store_connect/object/attributes.rb
+++ b/lib/app_store_connect/object/attributes.rb
@@ -19,7 +19,7 @@ module AppStoreConnect
         klass = Class.new do |attributes|
           include Object::Properties
 
-          attributes.define_method :initialize do |**kwargs|
+          attributes.send(:define_method,  :initialize) do |**kwargs|
             self.class.properties.each do |name, options|
               raise ArgumentError, "#{name} required" if options[:required] && !kwargs[name]
 

--- a/lib/app_store_connect/object/attributes.rb
+++ b/lib/app_store_connect/object/attributes.rb
@@ -19,7 +19,7 @@ module AppStoreConnect
         klass = Class.new do |attributes|
           include Object::Properties
 
-          attributes.send(:define_method,  :initialize) do |**kwargs|
+          attributes.send(:define_method, :initialize) do |**kwargs|
             self.class.properties.each do |name, options|
               raise ArgumentError, "#{name} required" if options[:required] && !kwargs[name]
 

--- a/lib/app_store_connect/object/data.rb
+++ b/lib/app_store_connect/object/data.rb
@@ -14,7 +14,7 @@ module AppStoreConnect
           include Object::Attributes
           include Object::Type
 
-          data.define_method :initialize do |**kwargs|
+          data.send(:define_method, :initialize) do |**kwargs|
             instance_variable_set('@relationships', kwargs.delete(:relationships).to_h)
             instance_variable_set('@attributes', data::Attributes.new(kwargs))
           end


### PR DESCRIPTION
Fixes #78 

It seems that in older versions of ruby `define_method` was private so we need to use `send(:define_method)`.