### PR TITLE
Remove max version limit for jwt dependency

### DIFF
--- a/app_store_connect.gemspec
+++ b/app_store_connect.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.7.0'
 
   spec.add_runtime_dependency 'activesupport', '>= 6.0.0'
-  spec.add_runtime_dependency 'jwt', '>= 1.4', '<= 2.5.0'
+  spec.add_runtime_dependency 'jwt', '>= 1.4'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'factory_bot', '~> 6.2.1'


### PR DESCRIPTION
Hi @kyledecot, this PR removes the max version limit for the jwt gem so that it won't be necessary to version bump jwt in this gem when new versions are released.

