### PR TITLE
Fix bug in BetaBuildLocalizationModifyRequest

### DIFF
--- a/lib/app_store_connect/beta_build_localization_modify_request.rb
+++ b/lib/app_store_connect/beta_build_localization_modify_request.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'app_store_connect/modify_request'
-
 module AppStoreConnect
   class BetaBuildLocalizationModifyRequest < Request::Body
     data do


### PR DESCRIPTION
A leftover `require` statement breaks execution in this class.