### PR TITLE
Update deprecated app price points endpoint

### DIFF
--- a/lib/config/schema.json
+++ b/lib/config/schema.json
@@ -308,7 +308,7 @@
     },
     {
       "http_method": "get",
-      "url": "https://api.appstoreconnect.apple.com/v1/apps/{id}/pricePoints",
+      "url": "https://api.appstoreconnect.apple.com/v1/apps/{id}/appPricePoints",
       "alias": "app_price_points"
     },
     {

--- a/spec/app_store_connect/client_spec.rb
+++ b/spec/app_store_connect/client_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe AppStoreConnect::Client do
 
     before { subject.app_price_points(id: id) }
 
-    it_behaves_like :get_request, path: 'apps/1234/pricePoints'
+    it_behaves_like :get_request, path: 'apps/1234/appPricePoints'
   end
 
   describe '#in_app_purchase' do


### PR DESCRIPTION
The endpoint for getting app price points [has recently been deprecated](https://developer.apple.com/documentation/appstoreconnectapi/app_store_connect_api_release_notes/app_store_connect_api_version_2_3_release_notes) and it should no longer be used.